### PR TITLE
Add Brackets Preferences support

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,8 +6,15 @@ define(function (require, exports, module) {
     "use strict";
 
     var DocumentManger = brackets.getModule("document/DocumentManager"),
-        EditorManager = brackets.getModule("editor/EditorManager");
-
+        EditorManager = brackets.getModule("editor/EditorManager"),
+        PreferencesManager = brackets.getModule("preferences/PreferencesManager"),
+        prefs = PreferencesManager.getExtensionPrefs("brackets-paste-and-indent");
+    
+    //prefix `brackets-paste-and-indent` is defined above
+    
+    //define the `enabled` preference, default is `true`
+    prefs.definePreference("enabled", "boolean", "true");
+    
     // Re-indent the editor in between specific lines. These are batched into
     // one update.
     function reindentLines(codeMirror, lineFrom, lineTo) {
@@ -27,7 +34,10 @@ define(function (require, exports, module) {
         }
         var codeMirror = editor._codeMirror;
         codeMirror.on("change", function (codeMirror, change) {
-            if (change.origin !== "paste") {
+            var enabled = prefs.get('enabled');
+            
+            //check it whether enabled
+            if (change.origin !== "paste" || !enabled) {
                 return;
             }
 


### PR DESCRIPTION
Some files may don't need re-indent when pasting, so add Preferences support, make it more flexible.
ლ(╹◡╹ლ)

disabled it by add

> "brackets-paste-and-indent.enabled": false

to ".brackets.json" file in the root of your project
